### PR TITLE
Always close the wallet the same way, and safely

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -467,8 +467,11 @@ namespace tools
     }
     MINFO("Stopping long poll thread");
     m_wallet->cancel_long_poll();
+    // Store this to revert it afterwards to its original state
+    bool disabled_state = m_long_poll_disabled;
     m_long_poll_disabled = true;
     m_long_poll_thread.join();
+    m_long_poll_disabled = disabled_state;
   }
   //------------------------------------------------------------------------------------------------------------------------------
   bool wallet_rpc_server::init()
@@ -579,6 +582,24 @@ namespace tools
   {
     if (!m_wallet)
       throw wallet_rpc_error{error_code::NOT_OPEN, "No wallet file"};
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
+  void wallet_rpc_server::close_wallet(bool save_current)
+  {
+    if (m_wallet)
+    {
+      LOG_PRINT_L0(tools::wallet_rpc_server::tr("Closing wallet..."));
+      stop_long_poll_thread();
+      if (save_current)
+      {
+        LOG_PRINT_L0(tools::wallet_rpc_server::tr("Saving wallet..."));
+        m_wallet->store();
+        LOG_PRINT_L0(tools::wallet_rpc_server::tr("Successfully saved"));
+      }
+      m_wallet->deinit();
+      m_wallet.reset();
+      LOG_PRINT_L0(tools::wallet_rpc_server::tr("Successfully closed"));
+    }
   }
   //------------------------------------------------------------------------------------------------------------------------------
   GET_BALANCE::response wallet_rpc_server::invoke(GET_BALANCE::request&& req)
@@ -2403,8 +2424,7 @@ namespace {
     else
       wal->generate(wallet_file, req.password);
 
-    if (m_wallet)
-      m_wallet->store();
+    close_wallet(true);
     m_wallet = std::move(wal);
     return {};
   }
@@ -2424,16 +2444,7 @@ namespace {
     if (ptr)
       throw wallet_rpc_error{error_code::UNKNOWN_ERROR, "Invalid filename"};
 
-    if (m_wallet)
-    {
-      // stopping the thread resets this but we want to turn it on again for the next wallet:
-      bool was_long_polling = !m_long_poll_disabled;
-      stop_long_poll_thread();
-      m_long_poll_disabled = !was_long_polling;
-      if (req.autosave_current)
-        m_wallet->store();
-      m_wallet.reset();
-    }
+    close_wallet(req.autosave_current);
 
     fs::path wallet_file = m_wallet_dir / fs::u8path(req.filename);
     auto vm2 = password_arg_hack(req.password, m_vm);
@@ -2450,11 +2461,7 @@ namespace {
   CLOSE_WALLET::response wallet_rpc_server::invoke(CLOSE_WALLET::request&& req)
   {
     require_open();
-
-    if (req.autosave_current)
-      m_wallet->store();
-    m_wallet.reset();
-
+    close_wallet(req.autosave_current);
     return {};
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -2515,11 +2522,7 @@ namespace {
     if (!viewkey_string.hex_to_pod(unwrap(unwrap(viewkey))))
       throw wallet_rpc_error{error_code::UNKNOWN_ERROR, "Failed to parse view key secret key"};
 
-    if (m_wallet && req.autosave_current)
-    {
-      if (!wallet_file.empty())
-        m_wallet->store();
-    }
+    close_wallet(req.autosave_current);
 
     {
       if (!req.spendkey.empty())
@@ -2572,8 +2575,7 @@ namespace {
       if (!crypto::ElectrumWords::words_to_bytes(req.seed, recovery_key, old_language))
         throw wallet_rpc_error{error_code::UNKNOWN_ERROR, "Electrum-style word list failed verification"};
     }
-    if (m_wallet && req.autosave_current)
-      m_wallet->store();
+    close_wallet(req.autosave_current);
 
     // process seed_offset if given
     {
@@ -3509,14 +3511,7 @@ namespace {
     LOG_PRINT_L0(tools::wallet_rpc_server::tr("Stopped wallet RPC server"));
     try
     {
-      if (m_wallet)
-      {
-        LOG_PRINT_L0(tools::wallet_rpc_server::tr("Saving wallet..."));
-        m_wallet->store();
-        m_wallet->deinit();
-        m_wallet.reset();
-        LOG_PRINT_L0(tools::wallet_rpc_server::tr("Successfully saved"));
-      }
+      close_wallet(true);
     }
     catch (const std::exception& e)
     {

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -588,17 +588,17 @@ namespace tools
   {
     if (m_wallet)
     {
-      LOG_PRINT_L0(tools::wallet_rpc_server::tr("Closing wallet..."));
+      MDEBUG(tools::wallet_rpc_server::tr("Closing wallet..."));
       stop_long_poll_thread();
       if (save_current)
       {
-        LOG_PRINT_L0(tools::wallet_rpc_server::tr("Saving wallet..."));
+        MDEBUG(tools::wallet_rpc_server::tr("Saving wallet..."));
         m_wallet->store();
-        LOG_PRINT_L0(tools::wallet_rpc_server::tr("Successfully saved"));
+        MINFO(tools::wallet_rpc_server::tr("Wallet saved"));
       }
       m_wallet->deinit();
       m_wallet.reset();
-      LOG_PRINT_L0(tools::wallet_rpc_server::tr("Successfully closed"));
+      MINFO(tools::wallet_rpc_server::tr("Wallet closed"));
     }
   }
   //------------------------------------------------------------------------------------------------------------------------------

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -176,6 +176,9 @@ namespace tools
       // Checks that a wallet is open; if not, throws an error.
       void require_open();
 
+      // Safely and cleanly closes the currently open wallet (if one is open)
+      void close_wallet(bool save_current);
+
       template<typename Ts, typename Tu>
       void fill_response(std::vector<tools::wallet2::pending_tx> &ptx_vector,
           bool get_tx_key, Ts& tx_key, Tu &amount, Tu &fee, std::string &multisig_txset, std::string &unsigned_txset, bool do_not_relay, bool blink,


### PR DESCRIPTION
This especially includes stopping the long-poll
loop thread, which otherwise causes a segfault.

Fixes #1398