### PR TITLE
Initialise m_should_use_bootstrap_daemon

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -221,6 +221,7 @@ namespace cryptonote { namespace rpc {
     )
     : m_core(cr)
     , m_p2p(p2p)
+    , m_should_use_bootstrap_daemon(false)
     , m_was_bootstrap_ever_used(false)
   {}
   bool core_rpc_server::set_bootstrap_daemon(const std::string &address, std::string_view username_password)


### PR DESCRIPTION
This boolean is otherwise uninitialised, leading
to unpredictable behaviour.

Fixes #1400